### PR TITLE
Добавить поддержку отрицающих правил

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/rumaster/facer/issues/7
+Your prepared branch: issue-7-990967a3dc36
+Your prepared working directory: /tmp/gh-issue-solver-1766848536024
+Your forked repository: konard/rumaster-facer
+Original repository (upstream): rumaster/facer
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/rumaster/facer/issues/7
-Your prepared branch: issue-7-990967a3dc36
-Your prepared working directory: /tmp/gh-issue-solver-1766848536024
-Your forked repository: konard/rumaster-facer
-Original repository (upstream): rumaster/facer
-
-Proceed.

--- a/gameplay.gd
+++ b/gameplay.gd
@@ -50,10 +50,20 @@ func _update_health_display():
 func _check_face_matches_rules() -> bool:
 	# Check if current face matches ALL rules
 	for rule in rules:
+		var is_negated = rule.get("negated", false)
 		for feature in rule.keys():
+			if feature == "negated":
+				continue
 			if current_face_config.has(feature):
-				if current_face_config[feature] != rule[feature]:
-					return false
+				var values_match = current_face_config[feature] == rule[feature]
+				# Для отрицающего правила: лицо подходит, если значение НЕ совпадает
+				# Для положительного правила: лицо подходит, если значение совпадает
+				if is_negated:
+					if values_match:
+						return false
+				else:
+					if not values_match:
+						return false
 			else:
 				return false
 	return true

--- a/main.gd
+++ b/main.gd
@@ -48,7 +48,9 @@ func _add_new_rule():
 	if available_features.size() > 0:
 		var random_feature = available_features.pick_random()
 		var random_value = feature_values[random_feature].pick_random()
-		rules.append({random_feature: random_value})
+		# Равно вероятно создаём положительное или отрицающее правило
+		var is_negated = randf() < 0.5
+		rules.append({random_feature: random_value, "negated": is_negated})
 
 func _show_rules():
 	# Hide gameplay if visible

--- a/rules.gd
+++ b/rules.gd
@@ -104,10 +104,16 @@ func _update_rules_display():
 	else:
 		text += "Условия для смахивания [b]ВПРАВО[/b]:\n\n"
 		for rule in rules:
+			var is_negated = rule.get("negated", false)
 			for feature in rule.keys():
+				if feature == "negated":
+					continue
 				var feature_name = feature_translations.get(feature, feature)
 				var value_name = value_translations.get(rule[feature], rule[feature])
-				text += "[b]" + feature_name + "[/b] = " + value_name + "\n"
+				if is_negated:
+					text += "[b]" + feature_name + "[/b] ≠ " + value_name + "\n"
+				else:
+					text += "[b]" + feature_name + "[/b] = " + value_name + "\n"
 		text += "\n[color=green]Если условия совпадают → ВПРАВО[/color]\n"
 		text += "[color=red]Иначе → ВЛЕВО[/color]\n"
 


### PR DESCRIPTION
## Summary
- Добавлен флаг `negated` для правил с 50% вероятностью (равно вероятно положительное и отрицающее правило)
- Обновлена логика проверки соответствия лица правилам для учёта отрицания
- На экране правил отрицающие условия отображаются со знаком ≠ (например: **Голова** ≠ квадратная)

## Implementation Details

### Изменения в `main.gd`:
- При создании нового правила с вероятностью 50% добавляется флаг `"negated": true`
- Формат правила: `{feature: value, "negated": true/false}`

### Изменения в `gameplay.gd`:
- Функция `_check_face_matches_rules()` теперь учитывает флаг отрицания
- Для положительного правила: лицо подходит, если значение совпадает
- Для отрицающего правила: лицо подходит, если значение НЕ совпадает

### Изменения в `rules.gd`:
- Отображение правил теперь показывает `=` для положительных и `≠` для отрицающих правил

## Examples

**Положительное правило:**
> **Голова** = квадратная
> (смахивай вправо, если голова квадратная)

**Отрицающее правило:**
> **Голова** ≠ квадратная
> (смахивай вправо, если голова НЕ квадратная)

## Test plan
- [ ] Запустить игру и убедиться, что правила генерируются как положительные, так и отрицающие
- [ ] Проверить отображение отрицающих правил со знаком ≠
- [ ] Проверить, что логика смахивания корректно работает для отрицающих правил
- [ ] Убедиться, что положительные правила работают как раньше

Fixes rumaster/facer#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)